### PR TITLE
Bind header/footer and document libraries

### DIFF
--- a/AvaloniaApp_Play/ViewModels/MainWindowViewModel.cs
+++ b/AvaloniaApp_Play/ViewModels/MainWindowViewModel.cs
@@ -12,7 +12,11 @@ public partial class MainWindowViewModel : ViewModelBase
     [ObservableProperty]
     private object? imageContent;
 
-    private int height = 20;
+    [ObservableProperty]
+    private string headerText = "Header";
+
+    [ObservableProperty]
+    private string footerText = "Footer";
 
     public MainWindowViewModel()
     { 

--- a/AvaloniaApp_Play/Views/MainWindow.axaml
+++ b/AvaloniaApp_Play/Views/MainWindow.axaml
@@ -30,7 +30,8 @@
         </Grid.RowDefinitions>
         
         <TextBlock Grid.Row="0"
-                   Name="Grid_Header" Text="Header" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                   Name="Grid_Header" Text="{Binding HeaderText}"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
 
         <!-- Dynamically switch between GIF and Image :D 
             I wrapped it in a view box because the layout 
@@ -56,6 +57,7 @@
         </Viewbox>
 
         <TextBlock Grid.Row="2"
-                   Name="Grid_Footer" Text="Footer" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                   Name="Grid_Footer" Text="{Binding FooterText}"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
     </Grid>
 </Window>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # AvaloniaApp_Play
+
+This project demonstrates migrating a simple WPF design to Avalonia using the MVVM pattern.
+
+## Libraries
+
+- **Avalonia.Labs.Gif** – provides `GifImage` to display GIF animations without relying on the WPF `WebBrowser` control.
+- **LibVLCSharp.Avalonia** – enables video playback across platforms as a replacement for the WPF `MediaElement`.
+
+All DTO classes remain unchanged to preserve the existing data contract.


### PR DESCRIPTION
## Summary
- use binding for header and footer text
- expose `HeaderText` and `FooterText` properties in the main window view model
- document library dependencies for GIF and video playback

## Testing
- `dotnet build AvaloniaApp_Play/AvaloniaApp_Play.csproj -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455ef2a6708326be1b1e9d3ae357d4