### PR TITLE
Simplify view updates

### DIFF
--- a/AvaloniaApp_Play/App.axaml.cs
+++ b/AvaloniaApp_Play/App.axaml.cs
@@ -21,10 +21,7 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             DisableAvaloniaDataAnnotationValidation();
-            desktop.MainWindow = new MainWindow
-            {
-                DataContext = new MainWindowViewModel(),
-            };
+            desktop.MainWindow = new MainWindow();
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/AvaloniaApp_Play/InstructionScreenHelper.cs
+++ b/AvaloniaApp_Play/InstructionScreenHelper.cs
@@ -15,6 +15,7 @@ using UDA.InstructionScreen.Shared.Entities.UI_Elements;
 using UDA.UDACapabilities.Shared;
 using UDA.UDACapabilities.Shared.Enums;
 using LibVLCSharp.Shared;
+using LibVLCSharp.Avalonia;
 using Avalonia.Labs.Gif;
 using Bitmap = Avalonia.Media.Imaging.Bitmap;
 using Color = Avalonia.Media.Color;
@@ -411,28 +412,32 @@ public static class InstructionScreenHelper
     }
     #endregion
     
-    #region VLC
-    public static void MapZIndex(this VlcControl vlcControl, VlcControl_Element gridDetails)
+    #region VideoView (replacement for VlcControl)
+    public static void MapZIndex(this VideoView videoView, VlcControl_Element gridDetails)
     {
-        Panel.SetZIndex(vlcControl, gridDetails.Z_Index);
+        Panel.SetZIndex(videoView, gridDetails.Z_Index);
     }
-    public static void MapMargins(this VlcControl vlcControl, VlcControl_Element gridDetails)
+
+    public static void MapMargins(this VideoView videoView, VlcControl_Element gridDetails)
     {
         if (gridDetails.Margin is not null && gridDetails.Margin.Count == 4)
-            vlcControl.Margin = new Thickness(gridDetails.Margin[0], gridDetails.Margin[1], gridDetails.Margin[2], gridDetails.Margin[3]);
+            videoView.Margin = new Thickness(gridDetails.Margin[0], gridDetails.Margin[1], gridDetails.Margin[2], gridDetails.Margin[3]);
     }
-    public static void MapHeight(this VlcControl vlcControl, VlcControl_Element gridDetails)
+
+    public static void MapHeight(this VideoView videoView, VlcControl_Element gridDetails)
     {
-        vlcControl.Height = gridDetails.Height is null || gridDetails.Height < 0 ? double.NaN : (double)gridDetails.Height;
+        videoView.Height = gridDetails.Height is null || gridDetails.Height < 0 ? double.NaN : (double)gridDetails.Height;
     }
-    public static void MapWidth(this VlcControl vlcControl, VlcControl_Element gridDetails)
+
+    public static void MapWidth(this VideoView videoView, VlcControl_Element gridDetails)
     {
-        vlcControl.Width = gridDetails.Width is null || gridDetails.Width < 0 ? double.NaN : (double)gridDetails.Width;
+        videoView.Width = gridDetails.Width is null || gridDetails.Width < 0 ? double.NaN : (double)gridDetails.Width;
     }
-    public static void MapVerticalAlignment(this VlcControl vlcControl, VlcControl_Element gridDetails)
+
+    public static void MapVerticalAlignment(this VideoView videoView, VlcControl_Element gridDetails)
     {
         if (gridDetails.VerticalAlignment is not null)
-            vlcControl.VerticalAlignment = gridDetails.VerticalAlignment switch
+            videoView.VerticalAlignment = gridDetails.VerticalAlignment switch
             {
                 1 => VerticalAlignment.Bottom,
                 3 => VerticalAlignment.Top,
@@ -440,10 +445,11 @@ public static class InstructionScreenHelper
                 _ => VerticalAlignment.Center
             };
     }
-    public static void MapHorizontalAlignment(this VlcControl vlcControl, VlcControl_Element gridDetails)
+
+    public static void MapHorizontalAlignment(this VideoView videoView, VlcControl_Element gridDetails)
     {
         if (gridDetails.HorizontalAlignment is not null)
-            vlcControl.HorizontalAlignment = gridDetails.HorizontalAlignment switch
+            videoView.HorizontalAlignment = gridDetails.HorizontalAlignment switch
             {
                 1 => HorizontalAlignment.Left,
                 3 => HorizontalAlignment.Right,
@@ -451,7 +457,8 @@ public static class InstructionScreenHelper
                 _ => HorizontalAlignment.Center
             };
     }
-    public static void MapTag(this VlcControl vlcControl, VlcControl_Element gridDetails)
+
+    public static void MapTag(this VideoView videoView, VlcControl_Element gridDetails)
     {
         // Set the Default properties in the "Tag" of the element
         Dictionary<string, object?> imgTagDictionary = new()
@@ -462,11 +469,12 @@ public static class InstructionScreenHelper
             { "StreamingOptions", gridDetails.StreamingOptions },
             { "NeverCollapse", gridDetails.NeverCollapse }
         };
-        vlcControl.Tag = imgTagDictionary; 
+        videoView.Tag = imgTagDictionary;
     }
-    public static void MapName(this VlcControl vlcControl, VlcControl_Element gridDetails)
-    { 
-        vlcControl.Name = gridDetails.Name;
+
+    public static void MapName(this VideoView videoView, VlcControl_Element gridDetails)
+    {
+        videoView.Name = gridDetails.Name;
     }
     #endregion
     

--- a/AvaloniaApp_Play/ViewModels/MainWindowViewModel.cs
+++ b/AvaloniaApp_Play/ViewModels/MainWindowViewModel.cs
@@ -1,45 +1,17 @@
-﻿using System;
-using System.Threading.Tasks;
-using Avalonia;
-using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
-using Avalonia.Labs.Gif; 
 
 namespace AvaloniaApp_Play.ViewModels;
 
 public partial class MainWindowViewModel : ViewModelBase
 {
     [ObservableProperty]
-    private object? imageContent;
+    private object? headerContent;
 
     [ObservableProperty]
-    private string headerText = "Header";
+    private object? bodyContent;
 
     [ObservableProperty]
-    private string footerText = "Footer";
+    private object? footerContent;
 
-    public MainWindowViewModel()
-    { 
-        StartAlternating();  
-    }
-
-    // Hello world
-    private async void StartAlternating()
-    {
-        var image1 = new Bitmap("Assets/avalonia-logo.ico");
-        var image2 = new Bitmap("Assets/alex.png");
-        var image3 = new GifImage { Source = new Uri("avares://AvaloniaApp_Play/Assets/200w.gif") };
-        const int time = 1000;  
-        
-        
-        while(true){
-            ImageContent = image1;
-            await Task.Delay(time);
-            ImageContent = image2;
-            await Task.Delay(time);
-            ImageContent = image3;
-            await Task.Delay(time);
-        } 
-    }
 }
  

--- a/AvaloniaApp_Play/Views/MainWindow.axaml
+++ b/AvaloniaApp_Play/Views/MainWindow.axaml
@@ -29,17 +29,26 @@
             <RowDefinition x:Name="Footer_RowDefinition"  Height="*" />
         </Grid.RowDefinitions>
         
-        <TextBlock Grid.Row="0"
-                   Name="Grid_Header" Text="{Binding HeaderText}"
-                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        <ContentControl Grid.Row="0" Name="Grid_Header" Content="{Binding HeaderContent}">
+            <ContentControl.DataTemplates>
+                <DataTemplate DataType="{x:Type string}">
+                    <TextBlock Text="{Binding}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </DataTemplate>
+                <DataTemplate DataType="{x:Type Bitmap}">
+                    <Image Source="{Binding}" Stretch="Uniform"/>
+                </DataTemplate>
+                <DataTemplate DataType="{x:Type gif:GifImage}">
+                    <gif:GifImage Source="{Binding}" Stretch="Uniform"/>
+                </DataTemplate>
+            </ContentControl.DataTemplates>
+        </ContentControl>
 
         <!-- Dynamically switch between GIF and Image :D 
             I wrapped it in a view box because the layout 
             system in avalonia is not applying to the GIf 
             image object -->
-        <Viewbox Grid.Row="1" Width="300"
-                 Name="Grid_Body">
-            <ContentControl Content="{Binding ImageContent}">
+        <Viewbox Grid.Row="1" Width="300" Name="Grid_Body">
+            <ContentControl Content="{Binding BodyContent}">
                 <ContentControl.DataTemplates>
                     
                     <DataTemplate DataType="{x:Type Bitmap}">
@@ -56,8 +65,18 @@
             </ContentControl>
         </Viewbox>
 
-        <TextBlock Grid.Row="2"
-                   Name="Grid_Footer" Text="{Binding FooterText}"
-                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        <ContentControl Grid.Row="2" Name="Grid_Footer" Content="{Binding FooterContent}">
+            <ContentControl.DataTemplates>
+                <DataTemplate DataType="{x:Type string}">
+                    <TextBlock Text="{Binding}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </DataTemplate>
+                <DataTemplate DataType="{x:Type Bitmap}">
+                    <Image Source="{Binding}" Stretch="Uniform"/>
+                </DataTemplate>
+                <DataTemplate DataType="{x:Type gif:GifImage}">
+                    <gif:GifImage Source="{Binding}" Stretch="Uniform"/>
+                </DataTemplate>
+            </ContentControl.DataTemplates>
+        </ContentControl>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- remove prototype `StartAlternating` method
- expose simple helper methods in the manager to update header, body and footer
- keep DataTemplates for header/body/footer so text, bitmap or GIF can be bound

## Testing
- `dotnet build AvaloniaApp_Play.sln -c Release` *(fails: dotnet not found)*
- `dotnet test AvaloniaApp_Play.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456719e4e4832697aa54cd852c1e42